### PR TITLE
Add basic auth to REST API

### DIFF
--- a/app/api/routes/v1.py
+++ b/app/api/routes/v1.py
@@ -1,7 +1,8 @@
 """Defines routes for v1 API."""
 from typing import Any, List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from fastapi.security import HTTPBasicCredentials
 
 from starlette import status
 
@@ -11,14 +12,22 @@ from app.api.schemas import (
     AssetInputSchema,
     AssetSchema,
     AnalystSchema,
+    SubscriptionInputSchema,
+    SubscriptionSchema,
 )
+from app.api.security import SECURITY, SECURITY_SERVICE
 from app.db.tables import AssetModel, AnalystModel
-from app.db.repositories import AssetRepository, AnalystRepository
+from app.db.repositories import (
+    AssetRepository,
+    AnalystRepository,
+    SubscriptionRepository,
+)
 
 API_PREFIX = "/api/v1"
 
 assets_repo = AssetRepository()
 analysts_repo = AnalystRepository()
+subscription_repo = SubscriptionRepository()
 
 api_v1_router = APIRouter(prefix=API_PREFIX)
 
@@ -31,10 +40,15 @@ async def get_assets():
 
 
 @api_v1_router.post(
-    "/assets", status_code=status.HTTP_201_CREATED, response_model=AssetSchema
+    "/assets",
+    status_code=status.HTTP_201_CREATED,
+    response_model=AssetSchema,
 )
-async def create_asset(payload: AssetInputSchema):
+async def create_asset(
+    payload: AssetInputSchema, credentials: HTTPBasicCredentials = Depends(SECURITY)
+):
     """Create a new asset."""
+    SECURITY_SERVICE.verify(credentials)
     asset = await assets_repo.create(payload)
     return asset
 
@@ -47,15 +61,23 @@ async def read_asset(asset_id: int):
 
 
 @api_v1_router.put("/assets/{asset_id}", response_model=AssetSchema)
-async def update_asset(asset_id: int, payload: AssetInputSchema):
+async def update_asset(
+    asset_id: int,
+    payload: AssetInputSchema,
+    credentials: HTTPBasicCredentials = Depends(SECURITY),
+):
     """Update information on asset given by `asset_id`."""
+    SECURITY_SERVICE.verify(credentials)
     asset = await assets_repo.update(asset_id, payload)
     return asset
 
 
 @api_v1_router.delete("/assets/{asset_id}", response_model=AssetSchema)
-async def delete_asset(asset_id: int):
+async def delete_asset(
+    asset_id: int, credentials: HTTPBasicCredentials = Depends(SECURITY)
+):
     """Delete asset from database."""
+    SECURITY_SERVICE.verify(credentials)
     asset = await assets_repo.delete(asset_id)
     return asset
 
@@ -70,8 +92,11 @@ async def get_analysts():
 @api_v1_router.post(
     "/analysts", status_code=status.HTTP_201_CREATED, response_model=AnalystSchema
 )
-async def create_analyst(payload: AnalystInputSchema):
+async def create_analyst(
+    payload: AnalystInputSchema, credentials: HTTPBasicCredentials = Depends(SECURITY)
+):
     """Add a new analyst to the database."""
+    SECURITY_SERVICE.verify(credentials)
     analyst = await analysts_repo.create(payload)
     return analyst
 
@@ -84,7 +109,11 @@ async def get_analyst_by_id(analyst_id: int):
 
 
 @api_v1_router.put("/analysts/{analyst_id}", response_model=AnalystSchema)
-async def update_analyst(analyst_id: int, payload: AnalystSchema):
+async def update_analyst(
+    analyst_id: int,
+    payload: AnalystSchema,
+    credentials: HTTPBasicCredentials = Depends(SECURITY),
+):
     """Update analyst information.
 
 
@@ -92,22 +121,37 @@ async def update_analyst(analyst_id: int, payload: AnalystSchema):
 
     The asset information must be complete - partial information update is not supported.
     """
+    SECURITY_SERVICE.verify(credentials)
     analyst = await analysts_repo.update(analyst_id, payload)
     return analyst
 
 
 @api_v1_router.delete("/analysts/{analyst_id}", response_model=AnalystSchema)
-async def delete_analyst(analyst_id: int):
+async def delete_analyst(
+    analyst_id: int, credentials: HTTPBasicCredentials = Depends(SECURITY)
+):
     """Delete analyst from database."""
+    SECURITY_SERVICE.verify(credentials)
     analyst = await analysts_repo.delete(analyst_id)
     return analyst
 
 
 @api_v1_router.post("/assets/subscription")
-async def subscribe_user_to_asset_events(payload: Any):
-    ...  # TODO: implement
+async def subscribe_user_to_asset_events(
+    payload: SubscriptionInputSchema,
+    credentials: HTTPBasicCredentials = Depends(SECURITY),
+):
+    SECURITY_SERVICE.verify(credentials)
+    subscription = await subscription_repo.create(payload)
+    return subscription
 
 
-@api_v1_router.delete("/subscriptions/{subscription_id}")
-async def unsubscribe_user_from_asset_events():
-    ...  # TODO: implement
+@api_v1_router.delete(
+    "/subscriptions/{subscription_id}", response_model=SubscriptionSchema
+)
+async def unsubscribe_user_from_asset_events(
+    subscription_id: int, credentials: HTTPBasicCredentials = Depends(SECURITY)
+):
+    SECURITY_SERVICE.verify(credentials)
+    subscription = await subscription_repo.delete(subscription_id)
+    return subscription

--- a/app/api/schemas.py
+++ b/app/api/schemas.py
@@ -1,7 +1,7 @@
 """Module for defining key schemas used within the REST API."""
 import datetime
 
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import pydantic
 import pydantic.main
@@ -70,3 +70,24 @@ class AssetSchema(_AssetBaseSchema, _AssetPrimaryKeySchema):
 
     # FIXME: bug with pydantic.BaseModel.from_orm() method in async SQLAlchemy mode
     # analyst: AnalystSchema
+
+
+class _SubscriptionBaseSchema(BaseSchema):
+    """Common subscription fields for the data model."""
+
+    email: pydantic.EmailStr
+    topic: Literal["asset::creation"] = "asset::creation"
+
+
+class SubscriptionInputSchema(_SubscriptionBaseSchema):
+    """Schema for representing user email subscription input data model."""
+
+
+class _SubscriptionPrimaryKeySchema(BaseSchema):
+    """Subscription primary key mixin."""
+
+    subscription_id: int = pydantic.Field(alias="id")
+
+
+class SubscriptionSchema(_SubscriptionBaseSchema, _SubscriptionPrimaryKeySchema):
+    """Full subscription model."""

--- a/app/api/security/__init__.py
+++ b/app/api/security/__init__.py
@@ -1,0 +1,30 @@
+import os
+
+from collections import defaultdict
+from typing import Any, Type
+
+from fastapi.security import HTTPBasic, HTTPBearer  # noqa: F401
+
+from .base_auth import BaseSecurityService
+from .basic_auth import BasicAuthSecurityService
+
+AUTH_TYPE_LOOKUP: dict[str, Type[BaseSecurityService]] = defaultdict(
+    lambda: BasicAuthSecurityService,
+    {
+        "basic": BasicAuthSecurityService,
+    },
+)
+
+AUTH_TYPE = AUTH_TYPE_LOOKUP[os.getenv("AUTH_TYPE")]
+
+
+SECURITY_TYPE_LOOKUP: dict[str, Any] = defaultdict(
+    lambda: HTTPBasic,
+    {
+        "basic": HTTPBasic,
+    },
+)
+
+SECURITY = SECURITY_TYPE_LOOKUP[AUTH_TYPE]()
+
+SECURITY_SERVICE: BaseSecurityService = AUTH_TYPE()

--- a/app/api/security/base_auth.py
+++ b/app/api/security/base_auth.py
@@ -1,0 +1,22 @@
+"""Provides `BaseSecurityService` class to act as security interface for different security solutions."""
+import abc
+
+from fastapi import status, HTTPException
+
+
+class BaseSecurityService(abc.ABC):
+    """Abstract base class for defining a security service interface."""
+
+    @staticmethod
+    def raise_401(detail="Unable to authenticate user", headers: dict | None = None):
+        """Raise 401 HTTP error to indicate user is not authorized."""
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=detail,
+            headers=headers or {},
+        )
+
+    @abc.abstractmethod
+    def verify(self, *args, **kwargs):
+        """Verify whether user is authenticated."""
+        ...

--- a/app/api/security/basic_auth.py
+++ b/app/api/security/basic_auth.py
@@ -1,0 +1,27 @@
+"""Provide a basic auth security service."""
+import os
+import secrets
+
+from fastapi import Depends
+from fastapi.security import HTTPBasicCredentials
+
+from .base_auth import BaseSecurityService
+
+
+class BasicAuthSecurityService(BaseSecurityService):
+    """Implements basic auth security service."""
+
+    def __init__(self):
+        self.username = os.getenv("BASIC_AUTH_USERNAME")
+        self.password = os.getenv("BASIC_AUTH_PASSWORD")
+
+    def verify(self, credentials, *args, **kwargs) -> None:
+        correct_credentials = secrets.compare_digest(
+            (credentials.username or "") + (credentials.password or ""),
+            (self.username or "") + (self.password or ""),
+        )
+        if not correct_credentials:
+            self.raise_401(
+                headers={"WWW-Authenticate": "Basic"},
+                detail="Incorrect email or password",
+            )

--- a/app/db/repositories/__init__.py
+++ b/app/db/repositories/__init__.py
@@ -2,3 +2,4 @@
 from .base_repository import BaseRepository  # noqa: F401
 from .analyst_repository import AnalystRepository  # noqa: F401
 from .asset_repository import AssetRepository  # noqa: F401
+from .subscription_repository import SubscriptionRepository  # noqa: F401

--- a/app/db/repositories/subscription_repository.py
+++ b/app/db/repositories/subscription_repository.py
@@ -1,0 +1,17 @@
+"""Provides `SubscriptionRepository` class to abstract data operations."""
+from typing import Type
+from .base_repository import BaseRepository
+from ..tables import SubscriptionModel
+from ...api.schemas import SubscriptionSchema
+
+
+class SubscriptionRepository(BaseRepository):
+    """Data repository for interacting with Subscriptions."""
+
+    @property
+    def _table(self) -> Type[SubscriptionModel]:
+        return SubscriptionModel
+
+    @property
+    def _schema(self) -> Type[SubscriptionSchema]:
+        return SubscriptionSchema

--- a/app/db/tables/__init__.py
+++ b/app/db/tables/__init__.py
@@ -1,3 +1,4 @@
 """ORM subpackage defining SQLAlchemy models mapping to SQL database tables."""
-from .analysts import AnalystModel
-from .assets import AssetModel
+from .analysts import AnalystModel  # noqa: F401
+from .assets import AssetModel  # noqa: F401
+from .subscriptions import SubscriptionModel  # noqa: F401

--- a/app/db/tables/subscriptions.py
+++ b/app/db/tables/subscriptions.py
@@ -1,0 +1,14 @@
+"""Provides SQLAlchemy ORM model defining a subscription."""
+from sqlalchemy import Column, Integer, String
+
+from app.db.tables.base import BaseModel
+
+
+class SubscriptionModel(BaseModel):
+    """ORM model defining an subscription."""
+
+    __tablename__ = "subscriptions"
+
+    id = Column(Integer, index=True, primary_key=True, unique=True)
+    email = Column(String, index=True, nullable=False)
+    topic = Column(String, nullable=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi[all]==0.77.1
+pydantic[email]==1.9.0
 fastapi-async-sqlalchemy==0.3.11
 mangum==0.15.0
 uvicorn==0.17.6


### PR DESCRIPTION
Protects non-read CRUD operations from unauthorized access using HTTP basic auth currently.